### PR TITLE
Move frontend dashboard to admin page

### DIFF
--- a/includes/class-inventory-admin-dashboard.php
+++ b/includes/class-inventory-admin-dashboard.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Admin dashboard for Inventory Manager Pro.
+ *
+ * @package Inventory_Manager_Pro
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Inventory_Admin_Dashboard {
+    private $plugin;
+
+    public function __construct( $plugin ) {
+        $this->plugin = $plugin;
+    }
+
+    public function register_menu() {
+        add_submenu_page(
+            'inventory-manager',
+            __( 'Dashboard', 'inventory-manager-pro' ),
+            __( 'Dashboard', 'inventory-manager-pro' ),
+            'manage_inventory',
+            'inventory-manager-dashboard',
+            array( $this, 'render_dashboard' )
+        );
+    }
+
+    public function enqueue_scripts( $hook ) {
+        if ( $hook !== 'inventory-manager_page_inventory-manager-dashboard' ) {
+            return;
+        }
+
+        wp_enqueue_style(
+            'inventory-manager',
+            INVENTORY_MANAGER_URL . 'assets/css/inventory-manager.css',
+            array(),
+            INVENTORY_MANAGER_VERSION
+        );
+
+        wp_enqueue_script(
+            'inventory-tables',
+            INVENTORY_MANAGER_URL . 'assets/js/inventory-tables.js',
+            array( 'jquery' ),
+            INVENTORY_MANAGER_VERSION,
+            true
+        );
+
+        wp_enqueue_script(
+            'inventory-logs',
+            INVENTORY_MANAGER_URL . 'assets/js/inventory-logs.js',
+            array( 'jquery' ),
+            INVENTORY_MANAGER_VERSION,
+            true
+        );
+
+        wp_enqueue_script(
+            'inventory-forms',
+            INVENTORY_MANAGER_URL . 'assets/js/inventory-forms.js',
+            array( 'jquery' ),
+            INVENTORY_MANAGER_VERSION,
+            true
+        );
+
+        wp_localize_script(
+            'inventory-tables',
+            'inventory_manager',
+            array(
+                'api_url' => rest_url( 'inventory-manager/v1' ),
+                'nonce'   => wp_create_nonce( 'wp_rest' ),
+                'pages'   => array(
+                    'add_manually' => admin_url( 'admin.php?page=inventory-manager-dashboard&tab=add-manually' ),
+                    'import'       => admin_url( 'admin.php?page=inventory-manager-dashboard&tab=import' ),
+                    'settings'     => admin_url( 'admin.php?page=inventory-manager-dashboard&tab=settings' ),
+                ),
+            )
+        );
+    }
+
+    public function render_dashboard() {
+        if ( ! $this->plugin->check_dashboard_access() ) {
+            wp_die( __( 'You do not have permission to access this page.', 'inventory-manager-pro' ) );
+        }
+
+        $tab = isset( $_GET['tab'] ) ? sanitize_text_field( $_GET['tab'] ) : 'overview';
+        echo '<div class="wrap inventory-manager">';
+        echo '<h1>' . esc_html__( 'Inventory Manager', 'inventory-manager-pro' ) . '</h1>';
+        echo '<h2 class="nav-tab-wrapper">';
+        $tabs = array(
+            'overview'      => __( 'Overview', 'inventory-manager-pro' ),
+            'detailed-logs' => __( 'Detailed Logs', 'inventory-manager-pro' ),
+            'add-manually'  => __( 'Add Manually', 'inventory-manager-pro' ),
+            'import'        => __( 'Import', 'inventory-manager-pro' ),
+            'settings'      => __( 'Settings', 'inventory-manager-pro' ),
+        );
+        foreach ( $tabs as $key => $label ) {
+            $class = ( $tab === $key ) ? ' nav-tab-active' : '';
+            echo '<a href="' . esc_url( admin_url( 'admin.php?page=inventory-manager-dashboard&tab=' . $key ) ) . '" class="nav-tab' . $class . '">' . esc_html( $label ) . '</a>';
+        }
+        echo '</h2>';
+
+        switch ( $tab ) {
+            case 'detailed-logs':
+                include $this->plugin->template_path() . 'dashboard/detailed-logs.php';
+                break;
+            case 'add-manually':
+                include $this->plugin->template_path() . 'dashboard/add-manually.php';
+                break;
+            case 'import':
+                include $this->plugin->template_path() . 'dashboard/import.php';
+                break;
+            case 'settings':
+                include $this->plugin->template_path() . 'dashboard/settings.php';
+                break;
+            default:
+                include $this->plugin->template_path() . 'dashboard/overview.php';
+                break;
+        }
+
+        echo '</div>';
+    }
+}

--- a/includes/class-inventory-manager.php
+++ b/includes/class-inventory-manager.php
@@ -56,8 +56,11 @@ class Inventory_Manager {
 		// The class responsible for defining API endpoints.
 		require_once INVENTORY_MANAGER_PATH . 'includes/class-inventory-api.php';
 
-		// The class responsible for defining all shortcodes.
-		require_once INVENTORY_MANAGER_PATH . 'includes/class-inventory-shortcodes.php';
+                // The class responsible for defining all shortcodes.
+                require_once INVENTORY_MANAGER_PATH . 'includes/class-inventory-shortcodes.php';
+
+                // Admin dashboard handler.
+                require_once INVENTORY_MANAGER_PATH . 'includes/class-inventory-admin-dashboard.php';
 
 		// The class responsible for integrating with WooCommerce.
 		require_once INVENTORY_MANAGER_PATH . 'includes/class-inventory-woocommerce.php';
@@ -91,9 +94,13 @@ class Inventory_Manager {
 		$this->loader->add_action( 'admin_enqueue_scripts', $this, 'enqueue_admin_styles' );
 		$this->loader->add_action( 'admin_enqueue_scripts', $this, 'enqueue_admin_scripts' );
 
-		$settings = new Inventory_Settings( $this );
-		$this->loader->add_action( 'admin_menu', $settings, 'add_settings_page' );
-		$this->loader->add_action( 'admin_init', $settings, 'register_settings' );
+                $settings = new Inventory_Settings( $this );
+                $this->loader->add_action( 'admin_menu', $settings, 'add_settings_page' );
+                $this->loader->add_action( 'admin_init', $settings, 'register_settings' );
+
+                $dashboard = new Inventory_Admin_Dashboard( $this );
+                $this->loader->add_action( 'admin_menu', $dashboard, 'register_menu' );
+                $this->loader->add_action( 'admin_enqueue_scripts', $dashboard, 'enqueue_scripts' );
 	}
 
 	/**

--- a/includes/class-inventory-settings.php
+++ b/includes/class-inventory-settings.php
@@ -36,32 +36,12 @@ class Inventory_Settings {
 			array( $this, 'render_settings_page' )
 		);
 
-		add_submenu_page(
-			'inventory-manager',
-			__( 'Dashboard', 'inventory-manager-pro' ),
-			__( 'Dashboard', 'inventory-manager-pro' ),
-			'manage_inventory',
-			'inventory-manager-dashboard',
-			array( $this, 'redirect_to_dashboard' )
-		);
-	}
+        }
 
-	/**
-	 * Redirect to frontend dashboard.
-	 */
-	public function redirect_to_dashboard() {
-		$dashboard_url = get_permalink( get_option( 'inventory_dashboard_page_id' ) );
-
-		if ( $dashboard_url ) {
-			wp_redirect( $dashboard_url );
-			exit;
-		}
-
-		echo '<div class="wrap">';
-		echo '<h1>' . __( 'Inventory Manager Dashboard', 'inventory-manager-pro' ) . '</h1>';
-		echo '<p>' . __( 'Dashboard page not found. Please check your settings.', 'inventory-manager-pro' ) . '</p>';
-		echo '</div>';
-	}
+        /**
+         * Redirect to frontend dashboard.
+         */
+        public function redirect_to_dashboard() {}
 
 	/**
 	 * Register settings.


### PR DESCRIPTION
## Summary
- create a new `Inventory_Admin_Dashboard` class
- load new admin dashboard and scripts from `Inventory_Manager`
- hook the dashboard into the admin menu and enqueue assets
- remove old dashboard redirection in settings

## Testing
- `php -l includes/class-inventory-admin-dashboard.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685029c5e2dc832ab339ed60133366e5