### PR TITLE
Add XLS export option and clean CSV data

### DIFF
--- a/assets/js/inventory-logs.js
+++ b/assets/js/inventory-logs.js
@@ -431,7 +431,7 @@
     function exportLogs() {
         // Prepare export params
         const params = {
-            format: 'csv', // Default to CSV
+            format: $('.logs-export-format').val() || 'csv',
             type: 'detailed-logs',
             period: state.period,
             search: state.search

--- a/assets/js/inventory-tables.js
+++ b/assets/js/inventory-tables.js
@@ -291,7 +291,7 @@
     function exportData() {
         // Prepare export params
         const params = {
-            format: 'csv', // Default to CSV
+            format: $('.export-format').val() || 'csv',
             type: 'overview',
             sku: '',
             search: state.filters.search,

--- a/includes/class-inventory-api.php
+++ b/includes/class-inventory-api.php
@@ -468,9 +468,15 @@ class Inventory_API {
 			foreach ( $batches as $batch ) {
 				$row = array();
 
-				foreach ( array_keys( $columns ) as $column_key ) {
-					$row[ $column_key ] = isset( $batch->$column_key ) ? $batch->$column_key : '';
-				}
+                                foreach ( array_keys( $columns ) as $column_key ) {
+                                        if ( 'stock_cost_formatted' === $column_key ) {
+                                                $row[ $column_key ] = isset( $batch->stock_cost ) ? $batch->stock_cost : '';
+                                        } elseif ( 'landed_cost_formatted' === $column_key ) {
+                                                $row[ $column_key ] = isset( $batch->landed_cost ) ? $batch->landed_cost : '';
+                                        } else {
+                                                $row[ $column_key ] = isset( $batch->$column_key ) ? wp_strip_all_tags( $batch->$column_key ) : '';
+                                        }
+                                }
 
 				$data[] = $row;
 			}

--- a/templates/dashboard/detailed-logs.php
+++ b/templates/dashboard/detailed-logs.php
@@ -45,6 +45,10 @@ if ( ! defined( 'ABSPATH' ) ) {
         </div>
         
         <div class="logs-export">
+            <select class="logs-export-format">
+                <option value="csv">CSV</option>
+                <option value="xls">XLS</option>
+            </select>
             <button class="button logs-export-btn"><?php _e( 'Export Logs', 'inventory-manager-pro' ); ?></button>
         </div>
     </div>

--- a/templates/dashboard/overview.php
+++ b/templates/dashboard/overview.php
@@ -74,8 +74,12 @@ $expiry_ranges = get_option( 'inventory_manager_expiry_ranges', array() );
 			<label><input type="checkbox" class="toggle-column" data-column="landed_cost" checked> <?php _e( 'LANDED COST', 'inventory-manager-pro' ); ?></label>
 		</div>
 		
-		<div class="actions">
-			<button class="button export-btn"><?php _e( 'EXPORT', 'inventory-manager-pro' ); ?></button>
+                <div class="actions">
+                        <select class="export-format">
+                                <option value="csv">CSV</option>
+                                <option value="xls">XLS</option>
+                        </select>
+                        <button class="button export-btn"><?php _e( 'EXPORT', 'inventory-manager-pro' ); ?></button>
 			<div class="search-box">
 				<input type="text" placeholder="<?php _e( 'Search...', 'inventory-manager-pro' ); ?>">
 				<button class="search-btn"><?php _e( 'Search', 'inventory-manager-pro' ); ?></button>


### PR DESCRIPTION
## Summary
- add dropdowns in dashboard for selecting export format
- allow JS to pass selected format for exports
- clean HTML from CSV exports for cost columns

## Testing
- `php -l includes/class-inventory-api.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68511cab3fc8832a851c24f6297cc6b3