### PR TITLE
Display costs in batch header

### DIFF
--- a/assets/js/inventory-logs.js
+++ b/assets/js/inventory-logs.js
@@ -244,6 +244,28 @@
         html += '<span class="label">Expiry</span>';
         html += '<span class="value">' + (batch.expiry_formatted || 'N/A') + '</span>';
         html += '</div>';
+
+        // Newly requested fields
+        html += '<div class="batch-unit-cost">';
+        html += '<span class="label">Unit Cost</span>';
+        html += '<span class="value">' + (parseFloat(batch.unit_cost || 0).toFixed(2)) + '</span>';
+        html += '</div>';
+
+        html += '<div class="batch-stock-cost">';
+        html += '<span class="label">Stock Cost</span>';
+        html += '<span class="value">' + (batch.stock_cost_formatted || parseFloat(batch.stock_cost || 0).toFixed(2)) + '</span>';
+        html += '</div>';
+
+        html += '<div class="batch-freight">';
+        html += '<span class="label">Freight Markup</span>';
+        html += '<span class="value">' + (parseFloat(batch.freight_markup || 0).toFixed(2)) + '</span>';
+        html += '</div>';
+
+        html += '<div class="batch-landed-cost">';
+        html += '<span class="label">Landed Cost</span>';
+        html += '<span class="value">' + (batch.landed_cost_formatted || parseFloat(batch.landed_cost || 0).toFixed(2)) + '</span>';
+        html += '</div>';
+
         html += '</div>'; // End batch-header
         
         // Batch details

--- a/templates/dashboard/detailed-logs.php
+++ b/templates/dashboard/detailed-logs.php
@@ -105,6 +105,26 @@ if ( ! defined( 'ABSPATH' ) ) {
                 <span class="label"><?php _e( 'Expiry', 'inventory-manager-pro' ); ?></span>
                 <span class="value">{{expiry_formatted}}</span>
             </div>
+
+            <div class="batch-unit-cost">
+                <span class="label"><?php _e( 'Unit Cost', 'inventory-manager-pro' ); ?></span>
+                <span class="value">{{unit_cost}}</span>
+            </div>
+
+            <div class="batch-stock-cost">
+                <span class="label"><?php _e( 'Stock Cost', 'inventory-manager-pro' ); ?></span>
+                <span class="value">{{stock_cost_formatted}}</span>
+            </div>
+
+            <div class="batch-freight">
+                <span class="label"><?php _e( 'Freight Markup', 'inventory-manager-pro' ); ?></span>
+                <span class="value">{{freight_markup}}</span>
+            </div>
+
+            <div class="batch-landed-cost">
+                <span class="label"><?php _e( 'Landed Cost', 'inventory-manager-pro' ); ?></span>
+                <span class="value">{{landed_cost_formatted}}</span>
+            </div>
         </div>
         
         <div class="batch-details" style="display: none;">


### PR DESCRIPTION
## Summary
- show unit cost, stock cost, freight markup and landed cost in each batch header on the detailed logs page

## Testing
- `php -l assets/js/inventory-logs.js` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685138fef95c832a8bcb9cdc695201f9