### PR TITLE
Add order dropdown and ascending log sorting

### DIFF
--- a/assets/js/inventory-logs.js
+++ b/assets/js/inventory-logs.js
@@ -10,6 +10,7 @@
     let state = {
         period: 'last_30_days',
         search: '',
+        order: 'ASC',
         products: []
     };
 
@@ -35,6 +36,12 @@
         // Period filter
         $('.period-filter').on('change', function() {
             state.period = $(this).val();
+            loadLogs();
+        });
+
+        // Order filter
+        $('.order-filter').on('change', function() {
+            state.order = $(this).val();
             loadLogs();
         });
         
@@ -92,7 +99,8 @@
         // Prepare request data
         const data = {
             period: state.period,
-            search: state.search
+            search: state.search,
+            order: state.order
         };
         
         // Make API request

--- a/includes/class-inventory-api.php
+++ b/includes/class-inventory-api.php
@@ -399,10 +399,11 @@ class Inventory_API {
 	public function get_detailed_logs( $request ) {
 		$params = $request->get_params();
 
-		$args = array(
-			'period' => isset( $params['period'] ) ? sanitize_text_field( $params['period'] ) : '',
-			'search' => isset( $params['search'] ) ? sanitize_text_field( $params['search'] ) : '',
-		);
+                $args = array(
+                        'period' => isset( $params['period'] ) ? sanitize_text_field( $params['period'] ) : '',
+                        'search' => isset( $params['search'] ) ? sanitize_text_field( $params['search'] ) : '',
+                        'order'  => isset( $params['order'] ) ? sanitize_text_field( $params['order'] ) : 'ASC',
+                );
 
 		$products = $this->db->get_detailed_logs( $args );
 

--- a/includes/class-inventory-database.php
+++ b/includes/class-inventory-database.php
@@ -566,6 +566,7 @@ class Inventory_Database {
         $defaults = array(
             'period' => '',
             'search' => '',
+            'order'  => 'ASC',
         );
 
         $args = wp_parse_args($args, $defaults);
@@ -666,7 +667,8 @@ class Inventory_Database {
                     }
                 }
 
-                $movements_query .= " ORDER BY m.date_created DESC";
+                $order = in_array(strtoupper($args['order']), array('ASC', 'DESC')) ? strtoupper($args['order']) : 'ASC';
+                $movements_query .= " ORDER BY m.date_created {$order}";
                 $batch->movements = $wpdb->get_results($movements_query);
             }
             // Add product to result
@@ -970,7 +972,7 @@ class Inventory_Database {
                 FROM {$wpdb->prefix}inventory_stock_movements m
                 LEFT JOIN {$wpdb->users} u ON m.created_by = u.ID
                 WHERE m.batch_id = %d
-                ORDER BY m.date_created DESC",
+                ORDER BY m.date_created ASC",
                 $batch_id
             )
         );

--- a/templates/dashboard/detailed-logs.php
+++ b/templates/dashboard/detailed-logs.php
@@ -44,6 +44,14 @@ if ( ! defined( 'ABSPATH' ) ) {
             <button class="button logs-search-btn"><?php _e( 'Search', 'inventory-manager-pro' ); ?></button>
             <button class="button show-all-batches-btn"><?php _e( 'Show All Batches', 'inventory-manager-pro' ); ?></button>
         </div>
+
+        <div class="logs-order">
+            <label for="order-filter"><?php _e( 'Order:', 'inventory-manager-pro' ); ?></label>
+            <select id="order-filter" class="order-filter">
+                <option value="ASC"><?php _e( 'Oldest First', 'inventory-manager-pro' ); ?></option>
+                <option value="DESC"><?php _e( 'Newest First', 'inventory-manager-pro' ); ?></option>
+            </select>
+        </div>
         
         <div class="logs-export">
             <select class="logs-export-format">


### PR DESCRIPTION
## Summary
- allow choosing log order via dropdown
- default detailed log sorting is oldest first
- send selected order to API and database queries

## Testing
- `php -l includes/class-inventory-database.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68513c59a3c0832ab6368fd93e4ae337