### PR TITLE
Map initial stock to Manual Entry

### DIFF
--- a/includes/class-inventory-database.php
+++ b/includes/class-inventory-database.php
@@ -670,6 +670,15 @@ class Inventory_Database {
                 $order = in_array(strtoupper($args['order']), array('ASC', 'DESC')) ? strtoupper($args['order']) : 'ASC';
                 $movements_query .= " ORDER BY m.date_created {$order}";
                 $batch->movements = $wpdb->get_results($movements_query);
+
+                // Replace initial stock movement type label
+                if ( ! empty( $batch->movements ) ) {
+                    foreach ( $batch->movements as $movement ) {
+                        if ( 'initial_stock' === $movement->movement_type ) {
+                            $movement->movement_type = __( 'Manual Entry', 'inventory-manager-pro' );
+                        }
+                    }
+                }
             }
             // Add product to result
             $result[] = array(
@@ -976,6 +985,14 @@ class Inventory_Database {
                 $batch_id
             )
         );
+
+        if ( ! empty( $movements ) ) {
+            foreach ( $movements as $movement ) {
+                if ( 'initial_stock' === $movement->movement_type ) {
+                    $movement->movement_type = __( 'Manual Entry', 'inventory-manager-pro' );
+                }
+            }
+        }
 
         return $movements;
     }


### PR DESCRIPTION
## Summary
- Map movement type `initial_stock` to `Manual Entry` when returning movements

## Testing
- `php -l includes/class-inventory-database.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68513e40b214832a98266d5cb96aec11