### PR TITLE
Fix movement type name for WooCommerce orders

### DIFF
--- a/includes/class-inventory-database.php
+++ b/includes/class-inventory-database.php
@@ -482,7 +482,7 @@ class Inventory_Database {
      *
      * @param int $batch_id Batch ID.
      * @param float $quantity Quantity to adjust (positive to add, negative to subtract).
-     * @param string $movement_type Type of movement (e.g., 'adjustment', 'invoice').
+     * @param string $movement_type Type of movement (e.g., 'adjustment', 'woo_order_placed').
      * @param string $reference Reference for the movement.
      * @return bool|WP_Error True on success or WP_Error on failure.
      */


### PR DESCRIPTION
## Summary
- shorten stock movement type name for WooCommerce order deductions
- update restoration logic to query using the new movement type
- note the new movement type in database docs

## Testing
- `php -l includes/class-inventory-woocommerce.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685158c00370832a9918ac737c7db203