### PR TITLE
Add settings tab to dashboard

### DIFF
--- a/includes/class-inventory-admin-dashboard.php
+++ b/includes/class-inventory-admin-dashboard.php
@@ -92,7 +92,7 @@ class Inventory_Admin_Dashboard {
             'detailed-logs' => __( 'Detailed Logs', 'inventory-manager-pro' ),
             'add-manually'  => __( 'Add Manually', 'inventory-manager-pro' ),
             'import'        => __( 'Import', 'inventory-manager-pro' ),
-            // 'settings'      => __( 'Settings', 'inventory-manager-pro' ),
+            'settings'      => __( 'Settings', 'inventory-manager-pro' ),
         );
         foreach ( $tabs as $key => $label ) {
             $class = ( $tab === $key ) ? ' nav-tab-active' : '';

--- a/templates/dashboard/settings.php
+++ b/templates/dashboard/settings.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Settings dashboard tab template
+ *
+ * @package Inventory_Manager_Pro
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+// Ensure settings class is available and output the settings page.
+$settings = new Inventory_Settings( null );
+$settings->render_settings_page();


### PR DESCRIPTION
## Summary
- enable the **Settings** tab on the admin dashboard
- render settings page content in a new dashboard template

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685433ed1bec832a99eea96e4cccddc5