### PR TITLE
Guard stock deduction for admin orders

### DIFF
--- a/includes/class-inventory-woocommerce.php
+++ b/includes/class-inventory-woocommerce.php
@@ -51,6 +51,20 @@ class Inventory_Manager_WooCommerce {
        public function process_order_stock_reduction( $order_id, $order ) {
                global $wpdb;
 
+               if ( ! $order instanceof WC_Order ) {
+                       $order = wc_get_order( $order_id );
+
+                       if ( ! $order ) {
+                               return;
+                       }
+               }
+
+               // For orders created in the admin, only deduct stock once the
+               // order is marked completed. This guards the processing hook.
+               if ( 'admin' === $order->get_created_via() && 'completed' !== $order->get_status() ) {
+                       return;
+               }
+
 		// Get settings
 		$stock_deduction_method = get_option( 'inventory_manager_frontend_deduction_method', 'closest_expiry' );
 


### PR DESCRIPTION
## Summary
- only reduce stock for admin-created orders when the order is completed
- ensure `process_order_stock_reduction` handles orders passed as IDs or objects

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68544416e410832aaad64ea2f297222d