### PR TITLE
Add toggle icons for product headers

### DIFF
--- a/assets/css/inventory-manager.css
+++ b/assets/css/inventory-manager.css
@@ -313,6 +313,13 @@
     min-width: 300px;
 }
 
+.inventory-manager .product-header .toggle-icon {
+    margin-left: auto;
+    font-size: 16px;
+    line-height: 1;
+    align-self: center;
+}
+
 .inventory-manager .product-summary > div {
     margin-right: 20px;
     margin-bottom: 10px;

--- a/assets/js/inventory-logs.js
+++ b/assets/js/inventory-logs.js
@@ -72,7 +72,17 @@
         
         // Toggle product details
         $(document).on('click', '.product-header', function() {
-            $(this).closest('.product-section').find('.batches-container').slideToggle();
+            const header = $(this);
+            header.closest('.product-section').find('.batches-container').slideToggle();
+
+            const icon = header.find('.toggle-icon');
+            if (header.hasClass('expanded')) {
+                header.removeClass('expanded');
+                icon.html('&#9660;');
+            } else {
+                header.addClass('expanded');
+                icon.html('&#9650;');
+            }
         });
         
         // Toggle batch details
@@ -219,8 +229,9 @@
         html += '<span class="label">Total Landed Cost</span>';
         html += '<span class="value">' + totalLandedCost.toFixed(2) + '</span>';
         html += '</div>';
-        
+
         html += '</div>'; // End product-summary
+        html += '<span class="toggle-icon">&#9660;</span>';
         html += '</div>'; // End product-header
         
         // Batches container

--- a/templates/dashboard/detailed-logs.php
+++ b/templates/dashboard/detailed-logs.php
@@ -77,18 +77,19 @@ if ( ! defined( 'ABSPATH' ) ) {
                 <strong>{{product_name}}</strong><br>
                 <span class="sku">SKU: {{sku}}</span>
             </div>
-            
+
             <div class="product-summary">
                 <div class="batch-count">
                     <span class="label"><?php _e( 'Batches', 'inventory-manager-pro' ); ?></span>
                     <span class="value">{{batch_count}}</span>
                 </div>
-                
+
                 <div class="total-stock">
                     <span class="label"><?php _e( 'Total Stock', 'inventory-manager-pro' ); ?></span>
                     <span class="value">{{total_stock}}</span>
                 </div>
             </div>
+            <span class="toggle-icon">&#9660;</span>
         </div>
         
         <div class="batches-container">


### PR DESCRIPTION
## Summary
- add toggle icons to product header template
- render toggle icons via JS
- toggle arrow direction when product headers are clicked
- style toggle icon

## Testing
- `php` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68590d670fac832a9983719200345d0a