### PR TITLE
Add option to decouple product stock from batches

### DIFF
--- a/includes/class-inventory-database.php
+++ b/includes/class-inventory-database.php
@@ -427,8 +427,8 @@ class Inventory_Database {
             )
         );
 
-        // Update product stock
-        $this->update_product_stock($product_id);
+        // Update product stock if syncing enabled
+        $this->update_product_stock( $product_id );
 
         return $batch_id;
     }
@@ -521,8 +521,8 @@ class Inventory_Database {
             array('id' => $batch_id)
         );
 
-        // Update product stock
-        $this->update_product_stock($batch->product_id);
+        // Update product stock if syncing enabled
+        $this->update_product_stock( $batch->product_id );
 
         return true;
     }
@@ -533,6 +533,11 @@ class Inventory_Database {
      * @param int $product_id Product ID.
      */
     public function update_product_stock($product_id) {
+        // Respect plugin setting to keep product stock independent
+        if ( 'yes' !== get_option( 'inventory_manager_sync_stock', 'yes' ) ) {
+            return;
+        }
+
         global $wpdb;
 
         // Get total stock for all batches

--- a/includes/class-inventory-settings.php
+++ b/includes/class-inventory-settings.php
@@ -50,7 +50,8 @@ class Inventory_Settings {
 		// Backend settings
 		register_setting( 'inventory_manager_backend', 'inventory_manager_backend_fields' );
 		register_setting( 'inventory_manager_backend', 'inventory_manager_backend_deduction_method' );
-		register_setting( 'inventory_manager_backend', 'inventory_manager_backend_select_batch' );
+                register_setting( 'inventory_manager_backend', 'inventory_manager_backend_select_batch' );
+                register_setting( 'inventory_manager_backend', 'inventory_manager_sync_stock' );
 
 		// Frontend settings
 		register_setting( 'inventory_manager_frontend', 'inventory_manager_frontend_fields' );
@@ -188,9 +189,9 @@ class Inventory_Settings {
 		echo '</td>';
 		echo '</tr>';
 
-		echo '<tr>';
-		echo '<th scope="row">' . __( 'Deduction Method', 'inventory-manager-pro' ) . '</th>';
-		echo '<td>';
+                echo '<tr>';
+                echo '<th scope="row">' . __( 'Deduction Method', 'inventory-manager-pro' ) . '</th>';
+                echo '<td>';
 		echo '<label>';
 		echo '<input type="radio" name="inventory_manager_backend_deduction_method" value="closest_expiry" ' . checked( $deduction_method, 'closest_expiry', false ) . '>';
 		echo __( 'Closest Expiry first', 'inventory-manager-pro' );
@@ -205,8 +206,29 @@ class Inventory_Settings {
 		echo '</td>';
 		echo '</tr>';
 
-		echo '</table>';
-	}
+                echo '</table>';
+
+                // Option to sync WooCommerce stock with batches
+                $sync_stock = get_option( 'inventory_manager_sync_stock', 'yes' );
+                echo '<h3>' . __( 'Sync Product Stock with Batches', 'inventory-manager-pro' ) . '</h3>';
+                echo '<table class="form-table">';
+                echo '<tr>';
+                echo '<th scope="row">' . __( 'Synchronize product stock', 'inventory-manager-pro' ) . '</th>';
+                echo '<td>';
+                echo '<label>';
+                echo '<input type="radio" name="inventory_manager_sync_stock" value="yes" ' . checked( $sync_stock, 'yes', false ) . '>';
+                echo __( 'Yes', 'inventory-manager-pro' );
+                echo '</label>';
+                echo '<br>';
+                echo '<label>';
+                echo '<input type="radio" name="inventory_manager_sync_stock" value="no" ' . checked( $sync_stock, 'no', false ) . '>';
+                echo __( 'No', 'inventory-manager-pro' );
+                echo '</label>';
+                echo '<p class="description">' . __( 'If disabled, WooCommerce product stock and batch stock will be managed separately.', 'inventory-manager-pro' ) . '</p>';
+                echo '</td>';
+                echo '</tr>';
+                echo '</table>';
+        }
 
 	/**
 	 * Render frontend settings.

--- a/includes/class-inventory-woocommerce.php
+++ b/includes/class-inventory-woocommerce.php
@@ -302,8 +302,12 @@ class Inventory_Manager_WooCommerce {
 	/**
 	 * Update WooCommerce product stock based on batch quantities.
 	 */
-	private function update_product_stock( $product_id ) {
-		global $wpdb;
+        private function update_product_stock( $product_id ) {
+                if ( 'yes' !== get_option( 'inventory_manager_sync_stock', 'yes' ) ) {
+                        return;
+                }
+
+                global $wpdb;
 
 		// Get total stock for all batches of this product
 		$total_stock = $wpdb->get_var(

--- a/inventory-manager-pro.php
+++ b/inventory-manager-pro.php
@@ -3,7 +3,7 @@
  * Plugin Name: Inventory Manager Pro
  * Plugin URI: https://example.com/inventory-manager-pro
  * Description: Advanced inventory management system for WooCommerce with batch tracking capabilities
- * Version: 2.2.2
+ * Version: 2.2.3
  * Author: Aurang Zeb
  * Author URI: https://aurang.dev
  * Text Domain: inventory-manager-pro
@@ -15,7 +15,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'INVENTORY_MANAGER_VERSION', '2.2.2' );
+define( 'INVENTORY_MANAGER_VERSION', '2.2.3' );
 define( 'INVENTORY_MANAGER_FILE', __FILE__ );
 define( 'INVENTORY_MANAGER_PATH', plugin_dir_path( __FILE__ ) );
 define( 'INVENTORY_MANAGER_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- add new `inventory_manager_sync_stock` setting
- skip WooCommerce stock updates when synchronization is disabled
- expose setting on backend settings page
- bump plugin version to 2.2.3

## Testing
- `php -l inventory-manager-pro.php` *(fails: php missing)*

------
https://chatgpt.com/codex/tasks/task_e_685abc255f9c832a89ef10f2dc01447c