### PR TITLE
Add supplier management to admin settings tab

### DIFF
--- a/assets/js/inventory-settings.js
+++ b/assets/js/inventory-settings.js
@@ -16,7 +16,7 @@
                     var row = $('<tr data-id="'+t.id+'">');
                     row.append('<td><input type="text" class="transit-id" value="'+t.id+'" disabled></td>');
                     row.append('<td><input type="text" class="transit-name" value="'+t.name+'"></td>');
-                    row.append('<td><button class="save-transit button">Save</button> <button class="delete-transit button">Delete</button></td>');
+                    row.append('<td><button class="save-transit button">Edit</button> <button class="delete-transit button">Delete</button></td>');
                     $('#transit-list').append(row);
                 });
                 if(callback) callback();
@@ -39,7 +39,7 @@
                     $('#new_supplier_transit option').clone().appendTo(select);
                     select.val(s.transit_time);
                     row.append($('<td>').append(select));
-                    row.append('<td><button class="save-supplier button">Save</button> <button class="delete-supplier button">Delete</button></td>');
+                    row.append('<td><button class="save-supplier button">Edit</button> <button class="delete-supplier button">Delete</button></td>');
                     $('#supplier-list').append(row);
                 });
             }

--- a/includes/class-inventory-manager.php
+++ b/includes/class-inventory-manager.php
@@ -94,9 +94,10 @@ class Inventory_Manager {
 		$this->loader->add_action( 'admin_enqueue_scripts', $this, 'enqueue_admin_styles' );
 		$this->loader->add_action( 'admin_enqueue_scripts', $this, 'enqueue_admin_scripts' );
 
-                $settings = new Inventory_Settings( $this );
-                $this->loader->add_action( 'admin_menu', $settings, 'add_settings_page' );
-                $this->loader->add_action( 'admin_init', $settings, 'register_settings' );
+               $settings = new Inventory_Settings( $this );
+               $this->loader->add_action( 'admin_menu', $settings, 'add_settings_page' );
+               $this->loader->add_action( 'admin_init', $settings, 'register_settings' );
+               $this->loader->add_action( 'admin_enqueue_scripts', $settings, 'enqueue_scripts' );
 
                 $dashboard = new Inventory_Admin_Dashboard( $this );
                 $this->loader->add_action( 'admin_menu', $dashboard, 'register_menu' );


### PR DESCRIPTION
## Summary
- enable editing suppliers and transit times within the Suppliers tab
- enqueue inventory settings scripts for this admin page
- update JS buttons to display "Edit" instead of "Save"

## Testing
- `php -l includes/class-inventory-settings.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685ae1b21ff8832a91ca472c167da05b