### PR TITLE
Add admin invoice/credit status hooks

### DIFF
--- a/includes/class-inventory-woocommerce.php
+++ b/includes/class-inventory-woocommerce.php
@@ -20,6 +20,8 @@ class Inventory_Manager_WooCommerce {
                add_action( 'woocommerce_order_status_completed', array( $this, 'process_order_stock_reduction' ), 10, 2 );
                add_action( 'woocommerce_order_status_cancelled', array( $this, 'process_order_stock_restoration' ), 10, 2 );
                add_action( 'woocommerce_order_status_refunded', array( $this, 'process_order_stock_restoration' ), 10, 2 );
+               add_action( 'woocommerce_order_status_wc-invoice', array( $this, 'admin_order_invoice_status' ), 10, 2 );
+               add_action( 'woocommerce_order_status_wc-credit-note', array( $this, 'admin_order_credit_note_status' ), 10, 2 );
 
 		// Product display.
                add_action( 'woocommerce_before_add_to_cart_form', array( $this, 'display_batch_info_single_product' ) );
@@ -769,6 +771,30 @@ class Inventory_Manager_WooCommerce {
                                        wc_delete_order_item_meta( $item_id, '_selected_batch_id' );
                                }
                        }
+               }
+       }
+
+       /**
+        * Deduct stock when an admin sets the order status to invoice.
+        *
+        * @param int      $order_id Order ID.
+        * @param WC_Order $order    Order object.
+        */
+       public function admin_order_invoice_status( $order_id, $order ) {
+               if ( $order && $order->get_created_via() === 'admin' ) {
+                       $this->process_order_stock_reduction( $order_id, $order );
+               }
+       }
+
+       /**
+        * Restore stock when an admin sets the order status to credit note.
+        *
+        * @param int      $order_id Order ID.
+        * @param WC_Order $order    Order object.
+        */
+       public function admin_order_credit_note_status( $order_id, $order ) {
+               if ( $order && $order->get_created_via() === 'admin' ) {
+                       $this->process_order_stock_restoration( $order_id, $order );
                }
        }
 


### PR DESCRIPTION
## Summary
- handle stock when admin sets custom statuses

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fb57a1c90832a8afcfe7d02b629ac