### PR TITLE
Add expiry range colors in logs

### DIFF
--- a/assets/js/inventory-logs.js
+++ b/assets/js/inventory-logs.js
@@ -303,7 +303,8 @@
         let html = '<div class="batch-section">';
         
         // Batch header
-        html += '<div class="batch-header">';
+        const expiryClass = batch.expiry_range ? ' expiry-' + batch.expiry_range : '';
+        html += '<div class="batch-header' + expiryClass + '">';
         html += '<div class="batch-number">';
         html += '<span class="label">Batch</span>';
         html += '<span class="value">' + batch.batch_number + '</span>';

--- a/includes/class-inventory-database.php
+++ b/includes/class-inventory-database.php
@@ -656,11 +656,32 @@ class Inventory_Database {
 
             // Format batches and get movements
             foreach ($batches as &$batch) {
-                // Format expiry date
+                // Format expiry date and determine expiry range
                 if (!empty($batch->expiry_date)) {
                     $batch->expiry_formatted = date_i18n(INVENTORY_MANAGER_DATE_FORMAT, strtotime($batch->expiry_date));
+
+                    // Determine expiry range similar to get_batches()
+                    $today  = time();
+                    $expiry = strtotime($batch->expiry_date);
+
+                    if ($expiry <= $today) {
+                        $batch->expiry_range = 'expired';
+                    } else {
+                        $diff_months = ($expiry - $today) / (30 * 24 * 60 * 60); // Approximate months
+
+                        if ($diff_months > 6) {
+                            $batch->expiry_range = '6plus';
+                        } elseif ($diff_months > 3) {
+                            $batch->expiry_range = '3-6';
+                        } elseif ($diff_months > 1) {
+                            $batch->expiry_range = '1-3';
+                        } else {
+                            $batch->expiry_range = 'less1';
+                        }
+                    }
                 } else {
                     $batch->expiry_formatted = '';
+                    $batch->expiry_range    = 'no_expiry';
                 }
 
                 // Get movements for this batch

--- a/templates/dashboard/detailed-logs.php
+++ b/templates/dashboard/detailed-logs.php
@@ -9,11 +9,34 @@
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
+
+// Get expiry ranges for dynamic colors
+$expiry_ranges = get_option( 'inventory_manager_expiry_ranges', array() );
 ?>
 <style>
     span.toggle-icon.dashicons.dashicons-arrow-down-alt2,span.toggle-icon.dashicons.dashicons-arrow-up-alt2 {
         font-size: 3rem;
         margin-right: 2rem;
+    }
+    .batch-header.expiry-expired {
+        background-color:<?php echo $expiry_ranges['expired']['color']; ?> !important;
+        color:<?php echo $expiry_ranges['expired']['text_color']; ?> !important;
+    }
+    .batch-header.expiry-less1 {
+        background-color:<?php echo $expiry_ranges['less_1']['color']; ?> !important;
+        color:<?php echo $expiry_ranges['less_1']['text_color']; ?> !important;
+    }
+    .batch-header.expiry-1-3 {
+        background-color:<?php echo $expiry_ranges['1_3']['color']; ?> !important;
+        color:<?php echo $expiry_ranges['1_3']['text_color']; ?> !important;
+    }
+    .batch-header.expiry-3-6 {
+        background-color:<?php echo $expiry_ranges['3_6']['color']; ?> !important;
+        color:<?php echo $expiry_ranges['3_6']['text_color']; ?> !important;
+    }
+    .batch-header.expiry-6plus {
+        background-color:<?php echo $expiry_ranges['6_plus']['color']; ?> !important;
+        color:<?php echo $expiry_ranges['6_plus']['text_color']; ?> !important;
     }
 </style>
 <div class="inventory-manager-logs">


### PR DESCRIPTION
## Summary
- compute expiry range data for batches in detailed logs
- color batch headers according to expiry ranges
- set up detailed logs template with expiry range styles

## Testing
- `php -l includes/class-inventory-database.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686229ca7680832a9868d1c7bcdb89c1