### PR TITLE
Upgrade expiry filters to colored buttons

### DIFF
--- a/assets/css/inventory-manager.css
+++ b/assets/css/inventory-manager.css
@@ -127,6 +127,26 @@
     cursor: pointer;
 }
 
+/* Style expiry filter buttons */
+.inventory-manager .expiry-filters input[type="checkbox"] {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.inventory-manager .expiry-filters label span {
+    display: inline-block;
+    padding: 4px 10px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+}
+
+.inventory-manager .expiry-filters input[type="checkbox"]:checked + span {
+    border-color: currentColor;
+    border-width: 2px;
+}
+
 .inventory-manager .search-box {
     display: flex;
     align-items: center;

--- a/templates/dashboard/detailed-logs.php
+++ b/templates/dashboard/detailed-logs.php
@@ -49,23 +49,23 @@ $expiry_ranges = get_option( 'inventory_manager_expiry_ranges', array() );
         <div class="expiry-filters">
             <label>
                 <input type="checkbox" class="filter-expiry" data-range="6+" checked>
-                <?php echo isset( $expiry_ranges['6_plus']['label'] ) ? esc_html( $expiry_ranges['6_plus']['label'] ) : __( '6+ months', 'inventory-manager-pro' ); ?>
+                <span class="expiry-6plus"><?php echo isset( $expiry_ranges['6_plus']['label'] ) ? esc_html( $expiry_ranges['6_plus']['label'] ) : __( '6+ months', 'inventory-manager-pro' ); ?></span>
             </label>
             <label>
                 <input type="checkbox" class="filter-expiry" data-range="3-6" checked>
-                <?php echo isset( $expiry_ranges['3_6']['label'] ) ? esc_html( $expiry_ranges['3_6']['label'] ) : __( '3-6 months', 'inventory-manager-pro' ); ?>
+                <span class="expiry-3-6"><?php echo isset( $expiry_ranges['3_6']['label'] ) ? esc_html( $expiry_ranges['3_6']['label'] ) : __( '3-6 months', 'inventory-manager-pro' ); ?></span>
             </label>
             <label>
                 <input type="checkbox" class="filter-expiry" data-range="1-3" checked>
-                <?php echo isset( $expiry_ranges['1_3']['label'] ) ? esc_html( $expiry_ranges['1_3']['label'] ) : __( '1-3 months', 'inventory-manager-pro' ); ?>
+                <span class="expiry-1-3"><?php echo isset( $expiry_ranges['1_3']['label'] ) ? esc_html( $expiry_ranges['1_3']['label'] ) : __( '1-3 months', 'inventory-manager-pro' ); ?></span>
             </label>
             <label>
                 <input type="checkbox" class="filter-expiry" data-range="<1" checked>
-                <?php echo isset( $expiry_ranges['less_1']['label'] ) ? esc_html( $expiry_ranges['less_1']['label'] ) : __( '< 1 month', 'inventory-manager-pro' ); ?>
+                <span class="expiry-less1"><?php echo isset( $expiry_ranges['less_1']['label'] ) ? esc_html( $expiry_ranges['less_1']['label'] ) : __( '< 1 month', 'inventory-manager-pro' ); ?></span>
             </label>
             <label>
                 <input type="checkbox" class="filter-expiry" data-range="expired" checked>
-                <?php echo isset( $expiry_ranges['expired']['label'] ) ? esc_html( $expiry_ranges['expired']['label'] ) : __( 'expired', 'inventory-manager-pro' ); ?>
+                <span class="expiry-expired"><?php echo isset( $expiry_ranges['expired']['label'] ) ? esc_html( $expiry_ranges['expired']['label'] ) : __( 'expired', 'inventory-manager-pro' ); ?></span>
             </label>
         </div>
     </div>

--- a/templates/dashboard/overview.php
+++ b/templates/dashboard/overview.php
@@ -39,27 +39,27 @@ $expiry_ranges = get_option( 'inventory_manager_expiry_ranges', array() );
 <div class="inventory-manager-overview">
 	<div class="filters-row">
 		<div class="expiry-filters">
-			<label>
-				<input type="checkbox" class="filter-expiry" data-range="6+" checked>
-				<?php echo isset( $expiry_ranges['6_plus']['label'] ) ? esc_html( $expiry_ranges['6_plus']['label'] ) : __( '6+ months', 'inventory-manager-pro' ); ?>
-			</label>
-			<label>
-				<input type="checkbox" class="filter-expiry" data-range="3-6" checked>
-				<?php echo isset( $expiry_ranges['3_6']['label'] ) ? esc_html( $expiry_ranges['3_6']['label'] ) : __( '3-6 months', 'inventory-manager-pro' ); ?>
-			</label>
-			<label>
-				<input type="checkbox" class="filter-expiry" data-range="1-3" checked>
-				<?php echo isset( $expiry_ranges['1_3']['label'] ) ? esc_html( $expiry_ranges['1_3']['label'] ) : __( '1-3 months', 'inventory-manager-pro' ); ?>
-			</label>
-			<label>
-				<input type="checkbox" class="filter-expiry" data-range="<1" checked>
-				<?php echo isset( $expiry_ranges['less_1']['label'] ) ? esc_html( $expiry_ranges['less_1']['label'] ) : __( '< 1 month', 'inventory-manager-pro' ); ?>
-			</label>
-			<label>
-				<input type="checkbox" class="filter-expiry" data-range="expired" checked>
-				<?php echo isset( $expiry_ranges['expired']['label'] ) ? esc_html( $expiry_ranges['expired']['label'] ) : __( 'expired', 'inventory-manager-pro' ); ?>
-			</label>
-		</div>
+                        <label>
+                                <input type="checkbox" class="filter-expiry" data-range="6+" checked>
+                                <span class="expiry-6plus"><?php echo isset( $expiry_ranges['6_plus']['label'] ) ? esc_html( $expiry_ranges['6_plus']['label'] ) : __( '6+ months', 'inventory-manager-pro' ); ?></span>
+                        </label>
+                        <label>
+                                <input type="checkbox" class="filter-expiry" data-range="3-6" checked>
+                                <span class="expiry-3-6"><?php echo isset( $expiry_ranges['3_6']['label'] ) ? esc_html( $expiry_ranges['3_6']['label'] ) : __( '3-6 months', 'inventory-manager-pro' ); ?></span>
+                        </label>
+                        <label>
+                                <input type="checkbox" class="filter-expiry" data-range="1-3" checked>
+                                <span class="expiry-1-3"><?php echo isset( $expiry_ranges['1_3']['label'] ) ? esc_html( $expiry_ranges['1_3']['label'] ) : __( '1-3 months', 'inventory-manager-pro' ); ?></span>
+                        </label>
+                        <label>
+                                <input type="checkbox" class="filter-expiry" data-range="<1" checked>
+                                <span class="expiry-less1"><?php echo isset( $expiry_ranges['less_1']['label'] ) ? esc_html( $expiry_ranges['less_1']['label'] ) : __( '< 1 month', 'inventory-manager-pro' ); ?></span>
+                        </label>
+                        <label>
+                                <input type="checkbox" class="filter-expiry" data-range="expired" checked>
+                                <span class="expiry-expired"><?php echo isset( $expiry_ranges['expired']['label'] ) ? esc_html( $expiry_ranges['expired']['label'] ) : __( 'expired', 'inventory-manager-pro' ); ?></span>
+                        </label>
+                </div>
 		
 		<div class="column-filters">
 			<label><input type="checkbox" class="toggle-column" data-column="sku" checked disabled> <?php _e( 'SKU', 'inventory-manager-pro' ); ?></label>


### PR DESCRIPTION
## Summary
- style expiry filter checkboxes as buttons
- convert expiry filter markup to use spans for color styling

## Testing
- `php -l templates/dashboard/overview.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686232b9d7d8832a962f85bb5ea7988e