### PR TITLE
Improve stock deduction and checkout notices

### DIFF
--- a/inventory-manager-pro.php
+++ b/inventory-manager-pro.php
@@ -3,7 +3,7 @@
  * Plugin Name: Inventory Manager Pro
  * Plugin URI: https://aurang.dev/inventory-manager-pro
  * Description: Advanced inventory management system for WooCommerce with batch tracking capabilities
- * Version: 2.2.8
+ * Version: 2.2.9
  * Author: Aurang Zeb
  * Author URI: https://aurang.dev
  * Text Domain: inventory-manager-pro
@@ -15,7 +15,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'INVENTORY_MANAGER_VERSION', '2.2.8' );
+define( 'INVENTORY_MANAGER_VERSION', '2.2.9' );
 define( 'INVENTORY_MANAGER_FILE', __FILE__ );
 define( 'INVENTORY_MANAGER_PATH', plugin_dir_path( __FILE__ ) );
 define( 'INVENTORY_MANAGER_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- include checkout stock notices for customers
- ensure selected batches are shown even when depleted
- track allocations for each order item
- bump plugin version to 2.2.9

## Testing
- `npm test` *(fails: package.json missing)*
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6862d7181a00832abb7c4e87cb9381b5