### PR TITLE
Add dynamic stock notifications on cart fragments refresh

### DIFF
--- a/assets/js/stock-notifications.js
+++ b/assets/js/stock-notifications.js
@@ -1,0 +1,79 @@
+/**
+ * Inventory Manager Pro - Stock Notifications
+ *
+ * Handles fetching and displaying stock notices when WooCommerce cart
+ * fragments are refreshed.
+ */
+(function($) {
+    'use strict';
+
+    /**
+     * Request stock notices from the server via AJAX.
+     */
+    function requestStockNotices() {
+        if (!inventory_stock_notices || !inventory_stock_notices.ajax_url) {
+            return;
+        }
+
+        $.ajax({
+            url: inventory_stock_notices.ajax_url,
+            method: 'POST',
+            data: {
+                action: 'inventory_manager_get_stock_notices',
+                security: inventory_stock_notices.nonce
+            },
+            success: function(response) {
+                console.log('Stock notices response:', response);
+                if (response.success && response.data && response.data.messages && response.data.messages.length) {
+                    $(document.body).trigger('inventory_stock_notices_received', [response.data.messages]);
+                }
+            }
+        });
+    }
+
+    /**
+     * Display notices inside a modal window.
+     *
+     * @param {Array} messages Array of notice strings.
+     */
+    function showNoticeModal(messages) {
+        if (!messages || !messages.length) {
+            return;
+        }
+
+        var html = '<div class="inventory-modal stock-notice-modal">';
+        html += '<div class="modal-content">';
+        html += '<div class="modal-header">';
+        html += '<h3>' + inventory_stock_notices.title + '</h3>';
+        html += '<button class="close-modal">&times;</button>';
+        html += '</div>';
+        html += '<div class="modal-body">';
+
+        $.each(messages, function(i, msg) {
+            html += '<p>' + msg + '</p>';
+        });
+
+        html += '</div></div></div>';
+        $('body').append(html);
+
+        $('.close-modal').on('click', function() {
+            $('.stock-notice-modal').remove();
+        });
+    }
+
+    // Listen for WooCommerce fragment refreshes
+    $(document.body).on('wc_fragments_refreshed', function() {
+        console.log('wc_fragments_refreshed detected');
+        requestStockNotices();
+    });
+
+    // Display modal when notices are received
+    $(document.body).on('inventory_stock_notices_received', function(event, messages) {
+        showNoticeModal(messages);
+    });
+
+    // Initial request in case fragments were loaded before script
+    $(function() {
+        requestStockNotices();
+    });
+})(jQuery);

--- a/includes/class-inventory-manager.php
+++ b/includes/class-inventory-manager.php
@@ -205,11 +205,31 @@ class Inventory_Manager {
 	 * @since    1.0.0
 	 */
 	public function enqueue_public_scripts() {
-		if ( $this->is_inventory_page() ) {
-			wp_enqueue_script(
-				'inventory-tables',
-				INVENTORY_MANAGER_URL . 'assets/js/inventory-tables.js',
-				array( 'jquery' ),
+               if ( is_cart() || is_checkout() ) {
+                       wp_enqueue_script(
+                               'inventory-stock-notices',
+                               INVENTORY_MANAGER_URL . 'assets/js/stock-notifications.js',
+                               array( 'jquery' ),
+                               INVENTORY_MANAGER_VERSION,
+                               true
+                       );
+
+                       wp_localize_script(
+                               'inventory-stock-notices',
+                               'inventory_stock_notices',
+                               array(
+                                       'ajax_url' => admin_url( 'admin-ajax.php' ),
+                                       'nonce'    => wp_create_nonce( 'inventory-manager-stock' ),
+                                       'title'    => __( 'Stock Notice', 'inventory-manager-pro' ),
+                               )
+                       );
+               }
+
+               if ( $this->is_inventory_page() ) {
+                       wp_enqueue_script(
+                               'inventory-tables',
+                               INVENTORY_MANAGER_URL . 'assets/js/inventory-tables.js',
+                               array( 'jquery' ),
 				INVENTORY_MANAGER_VERSION,
 				true
 			);

--- a/includes/class-inventory-woocommerce.php
+++ b/includes/class-inventory-woocommerce.php
@@ -45,6 +45,10 @@ class Inventory_Manager_WooCommerce {
                add_action( 'wp_ajax_get_product_batches', array( $this, 'get_product_batches' ) );
                add_action( 'wp_ajax_select_order_item_batch', array( $this, 'select_order_item_batch' ) );
 
+               // Stock notice retrieval via AJAX for cart fragment refreshes
+               add_action( 'wp_ajax_inventory_manager_get_stock_notices', array( $this, 'ajax_get_stock_notices' ) );
+               add_action( 'wp_ajax_nopriv_inventory_manager_get_stock_notices', array( $this, 'ajax_get_stock_notices' ) );
+
                // Detect quantity changes on admin order update.
                add_action( 'woocommerce_before_save_order_items', array( $this, 'maybe_adjust_order_item_quantities' ), 10, 2 );
 
@@ -1033,5 +1037,22 @@ class Inventory_Manager_WooCommerce {
         */
        public static function get_checkout_stock_messages() {
                return self::$checkout_stock_messages;
+       }
+
+       /**
+        * AJAX callback to retrieve checkout stock notices.
+        *
+        * Invoked when cart fragments are refreshed on the front-end to
+        * fetch any stock allocation messages for display in modals or
+        * custom interfaces.
+        */
+       public function ajax_get_stock_notices() {
+               $this->add_checkout_stock_notices();
+
+               wp_send_json_success(
+                       array(
+                               'messages' => self::get_checkout_stock_messages(),
+                       )
+               );
        }
 }


### PR DESCRIPTION
## Summary
- load new `stock-notifications.js` on cart and checkout pages
- add AJAX endpoint to retrieve checkout stock messages
- hook into `wc_fragments_refreshed` to fetch notices and open a modal

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6862f771bbd0832a80e0e9dbef380459