### PR TITLE
Implement AJAX batch import handler

### DIFF
--- a/assets/js/inventory-forms.js
+++ b/assets/js/inventory-forms.js
@@ -361,7 +361,13 @@
                 
                 const file = fileInput.files[0];
                 const formData = new FormData();
-                
+
+                // Required parameters for WordPress AJAX
+                formData.append('action', 'import_batches');
+                if (typeof inventory_manager_admin !== 'undefined') {
+                    formData.append('security', inventory_manager_admin.nonce);
+                }
+
                 formData.append('file', file);
                 
                 $.ajax({


### PR DESCRIPTION
## Summary
- add `import_batches` AJAX handler in plugin core
- hook new handler in admin hooks
- include action and nonce in batch import JS

## Testing
- `npm test` *(fails: package.json missing)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864eb9dd92c832aa724717c2ba78bc8