### PR TITLE
Add strict stock adjustment logic for backend orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,18 @@ Inventory_Manager_WooCommerce::get_checkout_stock_messages();
 
 Each call returns an array of notice strings that were generated during the
 current request.
+
+## Stock Deduction Logic
+
+Inventory Manager Pro tracks stock movements for each order item. The workflow
+differs slightly depending on where the order originated:
+
+- **Frontend orders** – stock is deducted immediately when a customer checks out.
+- **Backend orders** – created via the WooCommerce admin screen – stock is only
+  deducted once the order status is changed to `Invoice`.
+- When a backend order is changed to `Credit Note` the deducted quantities are
+  restored.
+
+Stock movements are logged against the order and item identifiers so the plugin
+can safely ignore duplicate events and maintain consistent product inventory
+levels.


### PR DESCRIPTION
## Summary
- prevent repeated stock deduction by skipping `process_order_stock_reduction` until backend orders reach the `Invoice` status
- block duplicate stock restorations and restrict them to the `Credit Note` status for backend orders
- document the frontend vs backend order rules in README

## Testing
- `php -l includes/class-inventory-woocommerce.php`
- `php -l inventory-manager-pro.php`

------
https://chatgpt.com/codex/tasks/task_e_687251a4381c832a906f295be44883c7