### PR TITLE
Add WooCommerce Brands settings tab

### DIFF
--- a/assets/js/inventory-manager.js
+++ b/assets/js/inventory-manager.js
@@ -34,6 +34,9 @@
 
             // Notification system
             this.initNotifications();
+
+            // Initialize brand selects on settings page
+            this.initBrandSelect();
         },
 
         /**
@@ -225,6 +228,9 @@
 
             // Dynamic field addition
             this.initDynamicFields();
+
+            // Initialize brand dropdowns
+            this.initBrandSelect();
         },
 
         /**
@@ -705,6 +711,17 @@
                 
                 $(this).closest('.dynamic-field').remove();
             });
+        },
+
+        /**
+         * Initialize Select2 for brand dropdowns
+         */
+        initBrandSelect: function() {
+            if ($.fn.selectWoo) {
+                $('.brand-select').selectWoo();
+            } else if ($.fn.select2) {
+                $('.brand-select').select2();
+            }
         },
 
         /**


### PR DESCRIPTION
## Summary
- register brand transit time settings
- add WooCommerce Brands tab to the settings navigation
- allow assigning transit times to brands in settings page
- integrate Select2 for brand dropdowns in admin JS

## Testing
- `php -l includes/class-inventory-settings.php`
- `node --check assets/js/inventory-manager.js`


------
https://chatgpt.com/codex/tasks/task_e_687f4db8d590832aa30e3ed9f050ad75