### PR TITLE
Add brands display on frontend

### DIFF
--- a/includes/class-inventory-settings.php
+++ b/includes/class-inventory-settings.php
@@ -560,9 +560,9 @@ class Inventory_Settings {
 		echo '<h3>' . __( 'Fields to Show on Frontend', 'inventory-manager-pro' ) . '</h3>';
 		echo '<table class="form-table">';
 
-		$field_options = array(
-			'supplier'  => __( 'Supplier', 'inventory-manager-pro' ),
-			'batch'     => __( 'Batch', 'inventory-manager-pro' ),
+                $field_options = array(
+                        'supplier'  => __( 'Brands', 'inventory-manager-pro' ),
+                        'batch'     => __( 'Batch', 'inventory-manager-pro' ),
 			'expiry'    => __( 'Expiry', 'inventory-manager-pro' ),
 			'origin'    => __( 'Origin', 'inventory-manager-pro' ),
 			'location'  => __( 'Location', 'inventory-manager-pro' ),

--- a/includes/class-inventory-shortcodes.php
+++ b/includes/class-inventory-shortcodes.php
@@ -139,20 +139,15 @@ class Inventory_Shortcodes {
 
                 $batches_info = array();
 
+                $brands      = wp_get_post_terms( $product_obj->get_id(), 'product_brand' );
+                $brand_names = '';
+                if ( ! is_wp_error( $brands ) && ! empty( $brands ) ) {
+                        $brand_names = implode( ', ', wp_list_pluck( $brands, 'name' ) );
+                }
+
                 foreach ( $batches as $batch ) {
-                        $supplier_name = '';
-
-                        if ( $batch->supplier_id ) {
-                                $supplier_name = $wpdb->get_var(
-                                        $wpdb->prepare(
-                                                "SELECT name FROM {$wpdb->prefix}inventory_suppliers WHERE id = %d",
-                                                $batch->supplier_id
-                                        )
-                                );
-                        }
-
                         $batches_info[] = array(
-                                'supplier'  => $supplier_name,
+                                'supplier'  => $brand_names,
                                 'batch'     => $batch->batch_number,
                                 'expiry'    => $batch->expiry_date ? date_i18n( INVENTORY_MANAGER_DATE_FORMAT, strtotime( $batch->expiry_date ) ) : '',
                                 'origin'    => $batch->origin,
@@ -227,20 +222,15 @@ class Inventory_Shortcodes {
 
                 $batches_info = array();
 
+                $brands      = wp_get_post_terms( $product->get_id(), 'product_brand' );
+                $brand_names = '';
+                if ( ! is_wp_error( $brands ) && ! empty( $brands ) ) {
+                        $brand_names = implode( ', ', wp_list_pluck( $brands, 'name' ) );
+                }
+
                 foreach ( $batches as $batch ) {
-                        $supplier_name = '';
-
-                        if ( $batch->supplier_id ) {
-                                $supplier_name = $wpdb->get_var(
-                                        $wpdb->prepare(
-                                                "SELECT name FROM {$wpdb->prefix}inventory_suppliers WHERE id = %d",
-                                                $batch->supplier_id
-                                        )
-                                );
-                        }
-
                         $batches_info[] = array(
-                                'supplier'  => $supplier_name,
+                                'supplier'  => $brand_names,
                                 'batch'     => $batch->batch_number,
                                 'expiry'    => $batch->expiry_date ? date_i18n( INVENTORY_MANAGER_DATE_FORMAT, strtotime( $batch->expiry_date ) ) : '',
                                 'origin'    => $batch->origin,


### PR DESCRIPTION
## Summary
- rename Supplier field to Brands in frontend settings
- show product brand names in product archive shortcode output
- show product brand names in single product shortcode output

## Testing
- `find includes -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_688a00a8c92c832abac03ed41a06685a