### PR TITLE
Fix settings menu routing

### DIFF
--- a/includes/class-inventory-admin-dashboard.php
+++ b/includes/class-inventory-admin-dashboard.php
@@ -18,7 +18,7 @@ class Inventory_Admin_Dashboard {
 
     public function register_menu() {
         add_submenu_page(
-            'inventory-manager',
+            'inventory-manager-settings',
             __( 'Dashboard', 'inventory-manager-pro' ),
             __( 'Dashboard', 'inventory-manager-pro' ),
             'manage_inventory',
@@ -28,7 +28,7 @@ class Inventory_Admin_Dashboard {
     }
 
     public function enqueue_scripts( $hook ) {
-        if ( $hook !== 'inventory-manager_page_inventory-manager-dashboard' ) {
+        if ( $hook !== 'inventory-manager-settings_page_inventory-manager-dashboard' ) {
             return;
         }
 

--- a/includes/class-inventory-settings.php
+++ b/includes/class-inventory-settings.php
@@ -19,25 +19,19 @@ class Inventory_Settings {
 	/**
 	 * Add settings page to admin menu.
 	 */
-	public function add_settings_page() {
-		add_menu_page(
-			__( 'Inventory Manager', 'inventory-manager-pro' ),
-			__( 'Inventory Manager', 'inventory-manager-pro' ),
-			'manage_inventory',
-			'inventory-manager',
-			array( $this, 'render_settings_page' ),
-			'dashicons-clipboard',
-			56
-		);
+        public function add_settings_page() {
+                add_menu_page(
+                        __( 'Inventory Manager Pro', 'inventory-manager-pro' ),
+                        __( 'Inventory Manager Pro', 'inventory-manager-pro' ),
+                        'manage_inventory',
+                        'inventory-manager-settings',
+                        array( $this, 'render_settings_page' ),
+                        'dashicons-clipboard',
+                        56
+                );
 
-		add_submenu_page(
-			'inventory-manager',
-			__( 'Settings', 'inventory-manager-pro' ),
-			__( 'Settings', 'inventory-manager-pro' ),
-			'manage_inventory',
-			'inventory-manager-settings',
-			array( $this, 'render_settings_page' )
-		);
+                // Remove automatically added first submenu to avoid duplicate
+                remove_submenu_page( 'inventory-manager-settings', 'inventory-manager-settings' );
 
         }
 


### PR DESCRIPTION
## Summary
- rename sidebar entry to Inventory Manager Pro
- remove extra menu page so clicking plugin title goes to settings
- update dashboard submenu parent

## Testing
- `php -l includes/class-inventory-settings.php`
- `php -l includes/class-inventory-admin-dashboard.php`
- `php -l inventory-manager-pro.php`

------
https://chatgpt.com/codex/tasks/task_e_688a03f41d00832aa5fa8903f3c931c5