### PR TITLE
Fix missing assets after plugin rename

### DIFF
--- a/assets/js/inventory-forms.js
+++ b/assets/js/inventory-forms.js
@@ -138,7 +138,7 @@
         const brandSelect = $('#brand_id');
 
         if (brandSelect.length) {
-            const baseUrl = inventory_manager.api_url.replace(/inventory-manager\/v1$/, '');
+            const baseUrl = inventory_manager.api_url.replace(/inventory-manager-pro\/v1$/, '');
 
             $.ajax({
                 url: baseUrl + 'wp/v2/product_brand?per_page=100',

--- a/includes/class-inventory-admin-dashboard.php
+++ b/includes/class-inventory-admin-dashboard.php
@@ -76,7 +76,7 @@ class Inventory_Admin_Dashboard {
             'inventory-tables',
             'inventory_manager',
             array(
-                'api_url' => rest_url( 'inventory-manager/v1' ),
+                'api_url' => rest_url( 'inventory-manager-pro/v1' ),
                 'nonce'   => wp_create_nonce( 'wp_rest' ),
                 'currency_symbol' => get_option( 'inventory_manager_currency', get_woocommerce_currency_symbol() ),
                 'pages'   => array(

--- a/includes/class-inventory-api.php
+++ b/includes/class-inventory-api.php
@@ -21,7 +21,7 @@ class Inventory_API {
 	public function register_routes() {
 		// Batches endpoints
 		register_rest_route(
-			'inventory-manager/v1',
+			'inventory-manager-pro/v1',
 			'/batches',
 			array(
 				'methods'             => 'GET',
@@ -31,7 +31,7 @@ class Inventory_API {
 		);
 
 		register_rest_route(
-			'inventory-manager/v1',
+			'inventory-manager-pro/v1',
 			'/batch/(?P<id>\d+)',
 			array(
 				'methods'             => 'GET',
@@ -41,7 +41,7 @@ class Inventory_API {
 		);
 
                 register_rest_route(
-                        'inventory-manager/v1',
+                        'inventory-manager-pro/v1',
                         '/batch',
                         array(
                                 'methods'             => 'POST',
@@ -51,7 +51,7 @@ class Inventory_API {
                 );
 
                 register_rest_route(
-                        'inventory-manager/v1',
+                        'inventory-manager-pro/v1',
                         '/batch/(?P<id>\d+)',
                         array(
                                 'methods'             => 'DELETE',
@@ -61,7 +61,7 @@ class Inventory_API {
                 );
 
                 register_rest_route(
-                        'inventory-manager/v1',
+                        'inventory-manager-pro/v1',
                         '/movement/(?P<id>\d+)',
                         array(
                                 'methods'             => 'DELETE',
@@ -72,7 +72,7 @@ class Inventory_API {
 
 		// Adjustment endpoint
 		register_rest_route(
-			'inventory-manager/v1',
+			'inventory-manager-pro/v1',
 			'/adjustment',
 			array(
 				'methods'             => 'POST',
@@ -83,7 +83,7 @@ class Inventory_API {
 
 		// Detailed logs endpoint
 		register_rest_route(
-			'inventory-manager/v1',
+			'inventory-manager-pro/v1',
 			'/detailed-logs',
 			array(
 				'methods'             => 'GET',
@@ -94,7 +94,7 @@ class Inventory_API {
 
 		// Export endpoints
 		register_rest_route(
-			'inventory-manager/v1',
+			'inventory-manager-pro/v1',
 			'/export',
 			array(
 				'methods'             => 'GET',
@@ -105,7 +105,7 @@ class Inventory_API {
 
 		// Helper endpoints
                 register_rest_route(
-                        'inventory-manager/v1',
+                        'inventory-manager-pro/v1',
                         '/suppliers',
                         array(
                                 'methods'             => 'GET',
@@ -115,7 +115,7 @@ class Inventory_API {
                 );
 
                 register_rest_route(
-                        'inventory-manager/v1',
+                        'inventory-manager-pro/v1',
                         '/suppliers',
                         array(
                                 'methods'             => 'POST',
@@ -125,7 +125,7 @@ class Inventory_API {
                 );
 
                 register_rest_route(
-                        'inventory-manager/v1',
+                        'inventory-manager-pro/v1',
                         '/suppliers/(?P<id>\d+)',
                         array(
                                 'methods'             => 'PUT',
@@ -135,7 +135,7 @@ class Inventory_API {
                 );
 
                 register_rest_route(
-                        'inventory-manager/v1',
+                        'inventory-manager-pro/v1',
                         '/suppliers/(?P<id>\d+)',
                         array(
                                 'methods'             => 'DELETE',
@@ -145,7 +145,7 @@ class Inventory_API {
                 );
 
                 register_rest_route(
-                        'inventory-manager/v1',
+                        'inventory-manager-pro/v1',
                         '/transit-times',
                         array(
                                 'methods'             => 'GET',
@@ -155,7 +155,7 @@ class Inventory_API {
                 );
 
                 register_rest_route(
-                        'inventory-manager/v1',
+                        'inventory-manager-pro/v1',
                         '/transit-times',
                         array(
                                 'methods'             => 'POST',
@@ -165,7 +165,7 @@ class Inventory_API {
                 );
 
                 register_rest_route(
-                        'inventory-manager/v1',
+                        'inventory-manager-pro/v1',
                         '/transit-times/(?P<id>[a-zA-Z0-9_-]+)',
                         array(
                                 'methods'             => 'PUT',
@@ -175,7 +175,7 @@ class Inventory_API {
                 );
 
                 register_rest_route(
-                        'inventory-manager/v1',
+                        'inventory-manager-pro/v1',
                         '/transit-times/(?P<id>[a-zA-Z0-9_-]+)',
                         array(
                                 'methods'             => 'DELETE',
@@ -185,7 +185,7 @@ class Inventory_API {
                 );
 
 		register_rest_route(
-			'inventory-manager/v1',
+			'inventory-manager-pro/v1',
 			'/adjustment-types',
 			array(
 				'methods'             => 'GET',
@@ -195,7 +195,7 @@ class Inventory_API {
 		);
 
 		register_rest_route(
-			'inventory-manager/v1',
+			'inventory-manager-pro/v1',
 			'/skus',
 			array(
 				'methods'             => 'GET',
@@ -205,7 +205,7 @@ class Inventory_API {
 		);
 
 		register_rest_route(
-			'inventory-manager/v1',
+			'inventory-manager-pro/v1',
 			'/product-info',
 			array(
 				'methods'             => 'GET',

--- a/includes/class-inventory-manager.php
+++ b/includes/class-inventory-manager.php
@@ -269,7 +269,7 @@ class Inventory_Manager {
 				'inventory-tables',
 				'inventory_manager',
                                 array(
-                                        'api_url' => rest_url( 'inventory-manager/v1' ),
+                                        'api_url' => rest_url( 'inventory-manager-pro/v1' ),
                                         'nonce'   => wp_create_nonce( 'wp_rest' ),
                                         'currency_symbol' => get_option( 'inventory_manager_currency', get_woocommerce_currency_symbol() ),
                                         'pages'   => array(


### PR DESCRIPTION
## Summary
- update REST API namespace to match new plugin slug
- adjust localized script data accordingly
- fix JS reference for brand routes

## Testing
- `php -l inventory-manager-pro.php`
- `find . -name '*.php' -print0 | xargs -0 -I {} php -l {}`


------
https://chatgpt.com/codex/tasks/task_e_688a065f0690832a9d584a23f1b7b58d