### PR TITLE
Auto-select brand when fetching product info

### DIFF
--- a/assets/js/inventory-forms.js
+++ b/assets/js/inventory-forms.js
@@ -99,7 +99,15 @@
                 if (response.product_name) {
                     $('#product_name').val(response.product_name);
                 }
-                
+
+                // Auto-select brand if available
+                if (response.brand_ids && response.brand_ids.length) {
+                    const brandSelect = $('#brand_id');
+                    const brandId = response.brand_ids[0];
+                    brandSelect.val(brandId);
+                    brandSelect.data('selected', brandId);
+                }
+
                 // Check if there are existing batches
                 if (response.batches && response.batches.length) {
                     // Show existing batches info
@@ -148,6 +156,11 @@
                         $.each(response, function(index, brand) {
                             brandSelect.append('<option value="' + brand.id + '">' + brand.name + '</option>');
                         });
+
+                        const selected = brandSelect.data('selected');
+                        if (selected) {
+                            brandSelect.val(selected);
+                        }
                     }
                 }
             });

--- a/assets/js/inventory-manager.js
+++ b/assets/js/inventory-manager.js
@@ -440,7 +440,15 @@
                     if (response.product_name) {
                         $('#product_name').val(response.product_name);
                     }
-                    
+
+                    // Auto-select brand if available
+                    if (response.brand_ids && response.brand_ids.length) {
+                        const brandSelect = $('#brand_id');
+                        const brandId = response.brand_ids[0];
+                        brandSelect.val(brandId);
+                        brandSelect.data('selected', brandId);
+                    }
+
                     // Check if there are existing batches
                     if (response.batches && response.batches.length) {
                         // Show existing batches info

--- a/includes/class-inventory-api.php
+++ b/includes/class-inventory-api.php
@@ -348,15 +348,21 @@ class Inventory_API {
 			return new WP_Error( 'product_not_found', 'Product not found for the given SKU.', array( 'status' => 404 ) );
 		}
 	
-		$product = wc_get_product( $product_id );
-		if ( ! $product ) {
-			return new WP_Error( 'invalid_product', 'Unable to load product object.', array( 'status' => 500 ) );
-		}
-	
-		// Initialize response
-		$response = array(
-			'product_name' => $product->get_name(),
-		);
+                $product = wc_get_product( $product_id );
+                if ( ! $product ) {
+                        return new WP_Error( 'invalid_product', 'Unable to load product object.', array( 'status' => 500 ) );
+                }
+
+                // Initialize response
+                $response = array(
+                        'product_name' => $product->get_name(),
+                );
+
+                // Get assigned brands for the product
+                $brand_ids = wp_get_post_terms( $product_id, 'product_brand', array( 'fields' => 'ids' ) );
+                if ( ! is_wp_error( $brand_ids ) && ! empty( $brand_ids ) ) {
+                        $response['brand_ids'] = array_map( 'intval', $brand_ids );
+                }
 	
 		// Fetch batches (if any) for this product and SKU
 		$table_batches = $wpdb->prefix . 'inventory_batches';


### PR DESCRIPTION
## Summary
- Include product brands in `product-info` REST response
- Auto-select the first associated brand when SKU data is fetched
- Preserve brand selection after brand list loads

## Testing
- `php -l includes/class-inventory-api.php`
- `npm test` *(fails: ENOENT package.json)*
- `composer test` *(fails: Command "test" is not defined)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892e805dfd8832a8cd349eccebad302