### PR TITLE
Add daterangepicker-based date range filter for detailed logs

### DIFF
--- a/assets/js/inventory-logs.js
+++ b/assets/js/inventory-logs.js
@@ -8,13 +8,15 @@
 
     // Current state
     let state = {
-        period: 'last_30_days',
+        period: 'this_month',
         batch_period: 'all',
         search: '',
         order: 'ASC',
         expiry_filters: [],
         products: [],
-        batch_sort: 'created'
+        batch_sort: 'created',
+        start_date: null,
+        end_date: null
     };
 
     /**
@@ -39,8 +41,40 @@
         // Period filter
         $('.period-filter').on('change', function() {
             state.period = $(this).val();
-            loadLogs();
+
+            if (state.period === 'custom') {
+                $('.custom-date-range').show();
+            } else {
+                $('.custom-date-range').hide();
+                state.start_date = null;
+                state.end_date = null;
+                loadLogs();
+            }
         });
+
+        // Initialize date range picker
+        if ($('.logs-date-range').length) {
+            $('.logs-date-range').daterangepicker({
+                autoUpdateInput: false,
+                locale: {
+                    cancelLabel: 'Clear',
+                    format: 'YYYY-MM-DD'
+                }
+            });
+
+            $('.logs-date-range').on('apply.daterangepicker', function(ev, picker) {
+                $(this).val(picker.startDate.format('YYYY-MM-DD') + ' - ' + picker.endDate.format('YYYY-MM-DD'));
+                state.start_date = picker.startDate.format('YYYY-MM-DD');
+                state.end_date = picker.endDate.format('YYYY-MM-DD');
+                loadLogs();
+            });
+
+            $('.logs-date-range').on('cancel.daterangepicker', function(ev, picker) {
+                $(this).val('');
+                state.start_date = null;
+                state.end_date = null;
+            });
+        }
 
         // Expiry filters
         $('.filter-expiry').on('change', function() {
@@ -191,6 +225,11 @@
             order: state.order,
             expiry_filters: state.expiry_filters
         };
+
+        if (state.period === 'custom' && state.start_date && state.end_date) {
+            data.start_date = state.start_date;
+            data.end_date = state.end_date;
+        }
         
         // Make API request
         $.ajax({
@@ -630,6 +669,11 @@
             search: state.search,
             expiry_filters: state.expiry_filters
         };
+
+        if (state.period === 'custom' && state.start_date && state.end_date) {
+            params.start_date = state.start_date;
+            params.end_date = state.end_date;
+        }
         
         // Create form and submit it
         const form = $('<form></form>')

--- a/includes/class-inventory-admin-dashboard.php
+++ b/includes/class-inventory-admin-dashboard.php
@@ -40,6 +40,13 @@ class Inventory_Admin_Dashboard {
         );
         wp_enqueue_style( 'dashicons' );
 
+        wp_enqueue_style(
+            'daterangepicker',
+            'https://cdn.jsdelivr.net/npm/daterangepicker/daterangepicker.css',
+            array(),
+            INVENTORY_MANAGER_VERSION
+        );
+
         wp_enqueue_script(
             'inventory-tables',
             INVENTORY_MANAGER_URL . 'assets/js/inventory-tables.js',
@@ -49,9 +56,25 @@ class Inventory_Admin_Dashboard {
         );
 
         wp_enqueue_script(
+            'moment',
+            'https://cdn.jsdelivr.net/npm/moment@2.29.4/moment.min.js',
+            array( 'jquery' ),
+            INVENTORY_MANAGER_VERSION,
+            true
+        );
+
+        wp_enqueue_script(
+            'daterangepicker',
+            'https://cdn.jsdelivr.net/npm/daterangepicker/daterangepicker.min.js',
+            array( 'jquery', 'moment' ),
+            INVENTORY_MANAGER_VERSION,
+            true
+        );
+
+        wp_enqueue_script(
             'inventory-logs',
             INVENTORY_MANAGER_URL . 'assets/js/inventory-logs.js',
-            array( 'jquery' ),
+            array( 'jquery', 'daterangepicker' ),
             INVENTORY_MANAGER_VERSION,
             true
         );

--- a/includes/class-inventory-api.php
+++ b/includes/class-inventory-api.php
@@ -489,6 +489,8 @@ class Inventory_API {
                         'search'        => isset( $params['search'] ) ? sanitize_text_field( $params['search'] ) : '',
                         'order'         => isset( $params['order'] ) ? sanitize_text_field( $params['order'] ) : 'ASC',
                         'expiry_filters'=> isset( $params['expiry_filters'] ) ? (array) $params['expiry_filters'] : array(),
+                        'start_date'    => isset( $params['start_date'] ) ? sanitize_text_field( $params['start_date'] ) : '',
+                        'end_date'      => isset( $params['end_date'] ) ? sanitize_text_field( $params['end_date'] ) : '',
                 );
 
 		$products = $this->db->get_detailed_logs( $args );
@@ -586,6 +588,8 @@ class Inventory_API {
                                 'batch_period'  => isset( $params['batch_period'] ) ? sanitize_text_field( $params['batch_period'] ) : '',
                                 'search'        => isset( $params['search'] ) ? sanitize_text_field( $params['search'] ) : '',
                                 'expiry_filters'=> isset( $params['expiry_filters'] ) ? (array) $params['expiry_filters'] : array(),
+                                'start_date'    => isset( $params['start_date'] ) ? sanitize_text_field( $params['start_date'] ) : '',
+                                'end_date'      => isset( $params['end_date'] ) ? sanitize_text_field( $params['end_date'] ) : '',
                         );
 
 			// Get detailed logs

--- a/includes/class-inventory-database.php
+++ b/includes/class-inventory-database.php
@@ -701,6 +701,8 @@ class Inventory_Database {
             'search'        => '',
             'order'         => 'ASC',
             'expiry_filters'=> array(),
+            'start_date'    => '',
+            'end_date'      => '',
         );
 
         $args = wp_parse_args($args, $defaults);
@@ -855,34 +857,42 @@ class Inventory_Database {
                 $movements_args = array($batch->id);
 
                 if (!empty($args['period'])) {
-                    switch ($args['period']) {
-                        case 'today':
-                            $movements_query .= " AND DATE(m.date_created) = CURDATE()";
-                            break;
-                        case 'yesterday':
-                            $movements_query .= " AND DATE(m.date_created) = DATE_SUB(CURDATE(), INTERVAL 1 DAY)";
-                            break;
-                        case 'this_week':
-                            $movements_query .= " AND YEARWEEK(m.date_created, 1) = YEARWEEK(CURDATE(), 1)";
-                            break;
-                        case 'last_week':
-                            $movements_query .= " AND YEARWEEK(m.date_created, 1) = YEARWEEK(CURDATE() - INTERVAL 1 WEEK, 1)";
-                            break;
-                        case 'this_month':
-                            $movements_query .= " AND MONTH(m.date_created) = MONTH(CURDATE()) AND YEAR(m.date_created) = YEAR(CURDATE())";
-                            break;
-                        case 'last_month':
-                            $movements_query .= " AND MONTH(m.date_created) = MONTH(CURDATE() - INTERVAL 1 MONTH) AND YEAR(m.date_created) = YEAR(CURDATE() - INTERVAL 1 MONTH)";
-                            break;
-                        case 'last_3_months':
-                            $movements_query .= " AND m.date_created >= CURDATE() - INTERVAL 3 MONTH";
-                            break;
-                        case 'last_6_months':
-                            $movements_query .= " AND m.date_created >= CURDATE() - INTERVAL 6 MONTH";
-                            break;
-                        case 'this_year':
-                            $movements_query .= " AND YEAR(m.date_created) = YEAR(CURDATE())";
-                            break;
+                    if ('custom' === $args['period'] && !empty($args['start_date']) && !empty($args['end_date'])) {
+                        $movements_query .= $wpdb->prepare(
+                            " AND DATE(m.date_created) BETWEEN %s AND %s",
+                            $args['start_date'],
+                            $args['end_date']
+                        );
+                    } else {
+                        switch ($args['period']) {
+                            case 'today':
+                                $movements_query .= " AND DATE(m.date_created) = CURDATE()";
+                                break;
+                            case 'yesterday':
+                                $movements_query .= " AND DATE(m.date_created) = DATE_SUB(CURDATE(), INTERVAL 1 DAY)";
+                                break;
+                            case 'this_week':
+                                $movements_query .= " AND YEARWEEK(m.date_created, 1) = YEARWEEK(CURDATE(), 1)";
+                                break;
+                            case 'last_week':
+                                $movements_query .= " AND YEARWEEK(m.date_created, 1) = YEARWEEK(CURDATE() - INTERVAL 1 WEEK, 1)";
+                                break;
+                            case 'this_month':
+                                $movements_query .= " AND MONTH(m.date_created) = MONTH(CURDATE()) AND YEAR(m.date_created) = YEAR(CURDATE())";
+                                break;
+                            case 'last_month':
+                                $movements_query .= " AND MONTH(m.date_created) = MONTH(CURDATE() - INTERVAL 1 MONTH) AND YEAR(m.date_created) = YEAR(CURDATE() - INTERVAL 1 MONTH)";
+                                break;
+                            case 'last_3_months':
+                                $movements_query .= " AND m.date_created >= CURDATE() - INTERVAL 3 MONTH";
+                                break;
+                            case 'last_6_months':
+                                $movements_query .= " AND m.date_created >= CURDATE() - INTERVAL 6 MONTH";
+                                break;
+                            case 'this_year':
+                                $movements_query .= " AND YEAR(m.date_created) = YEAR(CURDATE())";
+                                break;
+                        }
                     }
                 }
 

--- a/includes/class-inventory-manager.php
+++ b/includes/class-inventory-manager.php
@@ -233,21 +233,44 @@ class Inventory_Manager {
 	 */
 	public function enqueue_public_scripts() {
 		if ( $this->is_inventory_page() ) {
-			wp_enqueue_script(
-				'inventory-tables',
-				INVENTORY_MANAGER_URL . 'assets/js/inventory-tables.js',
-				array( 'jquery' ),
-				INVENTORY_MANAGER_VERSION,
-				true
-			);
+                        wp_enqueue_style(
+                                'daterangepicker',
+                                'https://cdn.jsdelivr.net/npm/daterangepicker/daterangepicker.css',
+                                array(),
+                                INVENTORY_MANAGER_VERSION
+                        );
 
-			wp_enqueue_script(
-				'inventory-logs',
-				INVENTORY_MANAGER_URL . 'assets/js/inventory-logs.js',
-				array( 'jquery' ),
-				INVENTORY_MANAGER_VERSION,
-				true
-			);
+                        wp_enqueue_script(
+                                'inventory-tables',
+                                INVENTORY_MANAGER_URL . 'assets/js/inventory-tables.js',
+                                array( 'jquery' ),
+                                INVENTORY_MANAGER_VERSION,
+                                true
+                        );
+
+                        wp_enqueue_script(
+                                'moment',
+                                'https://cdn.jsdelivr.net/npm/moment@2.29.4/moment.min.js',
+                                array( 'jquery' ),
+                                INVENTORY_MANAGER_VERSION,
+                                true
+                        );
+
+                        wp_enqueue_script(
+                                'daterangepicker',
+                                'https://cdn.jsdelivr.net/npm/daterangepicker/daterangepicker.min.js',
+                                array( 'jquery', 'moment' ),
+                                INVENTORY_MANAGER_VERSION,
+                                true
+                        );
+
+                        wp_enqueue_script(
+                                'inventory-logs',
+                                INVENTORY_MANAGER_URL . 'assets/js/inventory-logs.js',
+                                array( 'jquery', 'daterangepicker' ),
+                                INVENTORY_MANAGER_VERSION,
+                                true
+                        );
 
                         wp_enqueue_script(
                                 'inventory-forms',

--- a/templates/dashboard/detailed-logs.php
+++ b/templates/dashboard/detailed-logs.php
@@ -93,7 +93,7 @@ $expiry_ranges = get_option( 'inventory_manager_expiry_ranges', array() );
                 <option value="last_3_months"><?php _e( 'Last 3 Months', 'inventory-manager-pro' ); ?></option>
                 <option value="last_6_months"><?php _e( 'Last 6 Months', 'inventory-manager-pro' ); ?></option>
                 <option value="this_year"><?php _e( 'This Year', 'inventory-manager-pro' ); ?></option>
-                <!-- <option value="custom"><?php _e( 'Custom Range', 'inventory-manager-pro' ); ?></option> -->
+                <option value="custom"><?php _e( 'Custom Range', 'inventory-manager-pro' ); ?></option>
             </select>
 
             <div class="custom-date-range" style="display:none;">


### PR DESCRIPTION
## Summary
- add 'Custom Range' option to the logs period filter
- load daterangepicker and moment via CDN on public and admin pages
- enable date range selection in JS and send start/end dates to API
- support custom date ranges in API/database and exports

## Testing
- `php -l includes/class-inventory-manager.php`
- `php -l includes/class-inventory-admin-dashboard.php`
- `php -l includes/class-inventory-api.php`
- `php -l includes/class-inventory-database.php`
- `php -l templates/dashboard/detailed-logs.php`
- `node --check assets/js/inventory-logs.js`


------
https://chatgpt.com/codex/tasks/task_e_689308a48b80832a981679125c01374f